### PR TITLE
ci: Add release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,33 @@
+
+name: Release
+
+on: 
+  release:
+    types: [created]
+  workflow_dispatch:
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 20
+    
+      - name: Install dependencies
+        run: npm run  ci
+
+      - name: Build project
+        run: npm run vscode:prepublish
+
+      - name: Publish to VS Code Marketplace
+        uses: HaaLeo/publish-vscode-extension@v2
+        with:
+          pat: ${{ secrets.VSCE_PAT }}
+          registryUrl: https://marketplace.visualstudio.com
+          dependencies: false

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     ],
     "main": "./out/extension.js",
     "scripts": {
-        "vscode:prepublish": "npm run compile",
+        "vscode:prepublish": "npm run compile && npm run package",
         "compile": "tsc -p ./",
         "watch": "tsc -watch -p ./",
         "package": "vsce package"


### PR DESCRIPTION
- Added GitHub Actions workflow for releases.
- Automates publishing to VS Code Marketplace.
- Includes build and dependency steps.
- Uses `vsce` for packaging.
- Configured for Node.js 20

closes #4 